### PR TITLE
fixed import paths to use alexanderritola instead of daswasser

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package validate_test
 import (
 	"errors"
 	"fmt"
-	"github.com/daswasser/validate"
+	"github.com/alexanderritola/validate"
 )
 
 // This will be a method for verifying that we were given the string 'cat'.

--- a/simple/simple.go
+++ b/simple/simple.go
@@ -3,7 +3,7 @@ package simple
 
 import (
 	"errors"
-	"github.com/daswasser/validate"
+	"github.com/alexanderritola/validate"
 	"unicode"
 	"unicode/utf8"
 )

--- a/simple/simple_test.go
+++ b/simple/simple_test.go
@@ -1,7 +1,7 @@
 package simple
 
 import (
-	"github.com/daswasser/validate"
+	"github.com/alexanderritola/validate"
 	"testing"
 )
 

--- a/web/domain.go
+++ b/web/domain.go
@@ -5,7 +5,7 @@ package web
 import (
 	"bytes"
 	"errors"
-	"github.com/daswasser/validate"
+	"github.com/alexanderritola/validate"
 	"github.com/inhies/go-tld"
 	"unicode"
 	"unicode/utf8"

--- a/web/domain_test.go
+++ b/web/domain_test.go
@@ -2,7 +2,7 @@ package web
 
 import (
 	"fmt"
-	"github.com/daswasser/validate"
+	"github.com/alexanderritola/validate"
 	"testing"
 )
 

--- a/web/example_test.go
+++ b/web/example_test.go
@@ -2,8 +2,8 @@ package web_test
 
 import (
 	"fmt"
-	"github.com/daswasser/validate"
-	"github.com/daswasser/validate/web"
+	"github.com/alexanderritola/validate"
+	"github.com/alexanderritola/validate/web"
 )
 
 func ExampleDomain() {


### PR DESCRIPTION
I just saw that godoc is kind of broken since this project imports a renamed repository. See https://godoc.org/github.com/daswasser/validate#Error. Here I just renamed the broken import paths. 